### PR TITLE
Hotfix - Chart tooltips rendering

### DIFF
--- a/getmangoo-analytics/assets/js/dashboard/stats/graph/graph-util.js
+++ b/getmangoo-analytics/assets/js/dashboard/stats/graph/graph-util.js
@@ -130,10 +130,12 @@ export const GraphTooltip = (graphData, metric) => {
       }
 
       const data = tooltipModel.dataPoints[0]
-      const label = graphData.labels[data.dataIndex]
-      const point = data.raw || 0
-
       const prevData = hasPrevData ? tooltipModel.dataPoints.slice(-1)[0] : undefined
+
+      const pointHasData = hasPrevData ? data.datasetIndex !== prevData.datasetIndex : true;
+
+      const label = pointHasData ? graphData.labels[data.dataIndex] : undefined
+      const point = pointHasData ? data.raw || 0 : undefined
       const prevLabel = hasPrevData ? graphData.prev_labels[prevData.dataIndex] : undefined
       const prevPoint = hasPrevData ? prevData.raw || 0 : undefined
       // const pct_change = point === prev_point ? 0 : prev_point === 0 ? 100 : Math.round(((point - prev_point) / prev_point * 100).toFixed(1))

--- a/getmangoo-analytics/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/getmangoo-analytics/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -60,7 +60,7 @@ class LineGraph extends React.Component {
     const graphEl = document.getElementById("main-graph-canvas")
     this.ctx = graphEl.getContext('2d');
     const dataSet = buildDataSet(graphData.plot, graphData.present_index, this.ctx, METRIC_LABELS[metric])
-    const prevDataSet = graphData.prev_plot && buildDataSet(graphData.prev_plot, false, this.ctx, METRIC_LABELS[metric], true)
+    const prevDataSet = graphData.prev_labels && graphData.prev_plot && buildDataSet(graphData.prev_plot, false, this.ctx, METRIC_LABELS[metric], true)
     const combinedDataSets = prevDataSet ? [...dataSet, ...prevDataSet] : dataSet;
 
     return new Chart(this.ctx, {


### PR DESCRIPTION
Added a new verification on tooltips rendering function to check if the main dataset has no data on the given chart point.

It was rendering two tooltips even if only the comparison dataset has data, as shown in the image bellow.

![tooltip-bug-duplicated-comparison-data](https://user-images.githubusercontent.com/26199302/213884614-d230e09b-2b9b-4da2-8799-8a0e2bfbfa6a.png)

After this fix only one tooltip is rendered, as expected.

![tooltip-bug-duplicated-comparison-data-fix](https://user-images.githubusercontent.com/26199302/213884664-d1973e87-456f-4b2f-9011-5c489b195552.png)

