### PR TITLE
Fixed graph tooltip bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We leverage Plausible's open source software to get started. Plausible Analytics
 
 Our Modifications are as follows:
 
-- Jan 2023: Added comparison options to main charts. Users will now be able to comapre to previous periods or same period in the previous year to compare performance over time
+- Jan 2023: Added comparison options to main charts. Users will now be able to compare to previous periods or same period in the previous year to compare performance over time
 
 - Dec 2022: Removed Google console integration as we look forward to adding other integration and might bring back the google integration in the future. ‍
 

--- a/getmangoo-analytics/assets/js/dashboard/stats/graph/graph-util.js
+++ b/getmangoo-analytics/assets/js/dashboard/stats/graph/graph-util.js
@@ -5,28 +5,32 @@ export const dateFormatter = (interval, longForm) => {
   return function (isoDate, _index, _ticks) {
     if (!isoDate) return '';
 
-    let date = parseDate(isoDate)
 
-    if (interval === 'month') {
-      return formatMonthYYYY(date);
-    } else if (interval === 'date') {
-      return formatDay(date);
-    } else if (interval === 'hour') {
-      const dateFormat = Intl.DateTimeFormat(navigator.language, { hour: 'numeric' })
-      const twelveHourClock = dateFormat.resolvedOptions().hour12
-      const formattedHours = dateFormat.format(date)
-
-      if (twelveHourClock) {
-        return formattedHours.replace(' ', '').toLowerCase()
-      } else {
-        return formattedHours.replace(/[^0-9]/g, '').concat(":00")
-      }
-    } else if (interval === 'minute') {
+    if (interval === 'minute') {
       if (longForm) {
-        const minutesAgo = Math.abs(isoDate)
-        return minutesAgo === 1 ? '1 minute ago' : minutesAgo + ' minutes ago'
+        const minutesAgo = Math.abs(isoDate);
+        return minutesAgo === 1 ? '1 minute ago' : minutesAgo + ' minutes ago';
       } else {
-        return isoDate + 'm'
+        return isoDate + 'm';
+      }
+    }
+    else {
+      const date = parseDate(isoDate);
+
+      if (interval === 'month') {
+        return formatMonthYYYY(date);
+      } else if (interval === 'date') {
+        return formatDay(date);
+      } else if (interval === 'hour') {
+        const dateFormat = Intl.DateTimeFormat(navigator.language, { hour: 'numeric' });
+        const twelveHourClock = dateFormat.resolvedOptions().hour12;
+        const formattedHours = dateFormat.format(date);
+
+        if (twelveHourClock) {
+          return formattedHours.replace(' ', '').toLowerCase();
+        } else {
+          return formattedHours.replace(/[^0-9]/g, '').concat(":00");
+        }
       }
     }
   }

--- a/getmangoo-analytics/assets/js/dashboard/stats/graph/graph-util.js
+++ b/getmangoo-analytics/assets/js/dashboard/stats/graph/graph-util.js
@@ -1,20 +1,17 @@
 import { METRIC_LABELS, METRIC_FORMATTER } from './visitor-graph'
-import { parseUTCDate, formatMonthYYYY, formatDay } from '../../util/date'
+import { parseDate, formatMonthYYYY, formatDay } from '../../util/date'
 
 export const dateFormatter = (interval, longForm) => {
   return function (isoDate, _index, _ticks) {
     if (!isoDate) return '';
 
-    let date = parseUTCDate(isoDate)
+    let date = parseDate(isoDate)
 
     if (interval === 'month') {
       return formatMonthYYYY(date);
     } else if (interval === 'date') {
       return formatDay(date);
     } else if (interval === 'hour') {
-      const parts = isoDate.split(/[^0-9]/);
-      date = new Date(parts[0], parts[1] - 1, parts[2], parts[3], parts[4], parts[5])
-
       const dateFormat = Intl.DateTimeFormat(navigator.language, { hour: 'numeric' })
       const twelveHourClock = dateFormat.resolvedOptions().hour12
       const formattedHours = dateFormat.format(date)

--- a/getmangoo-analytics/assets/js/dashboard/stats/graph/graph-util.js
+++ b/getmangoo-analytics/assets/js/dashboard/stats/graph/graph-util.js
@@ -127,14 +127,12 @@ export const GraphTooltip = (graphData, metric) => {
       }
 
       const data = tooltipModel.dataPoints[0]
+      const label = !data.dataset.isPrevious ? graphData.labels[data.dataIndex] : undefined
+      const point = !data.dataset.isPrevious ? data.raw || 0 : undefined
+
       const prevData = hasPrevData ? tooltipModel.dataPoints.slice(-1)[0] : undefined
-
-      const pointHasData = hasPrevData ? data.datasetIndex !== prevData.datasetIndex : true;
-
-      const label = pointHasData ? graphData.labels[data.dataIndex] : undefined
-      const point = pointHasData ? data.raw || 0 : undefined
-      const prevLabel = hasPrevData ? graphData.prev_labels[prevData.dataIndex] : undefined
-      const prevPoint = hasPrevData ? prevData.raw || 0 : undefined
+      const prevLabel = prevData && prevData.dataset.isPrevious ? graphData.prev_labels[prevData.dataIndex] : undefined
+      const prevPoint = prevData && prevData.dataset.isPrevious ? prevData.raw || 0 : undefined
       // const pct_change = point === prev_point ? 0 : prev_point === 0 ? 100 : Math.round(((point - prev_point) / prev_point * 100).toFixed(1))
 
       let innerHtml = `
@@ -184,6 +182,7 @@ export const buildDataSet = (plot, present_index, ctx, label, isPrevious) => {
         pointHoverRadius: 4,
         backgroundColor: gradient,
         fill: true,
+        isPrevious: isPrevious
       },
       {
         label,
@@ -196,6 +195,7 @@ export const buildDataSet = (plot, present_index, ctx, label, isPrevious) => {
         pointHoverRadius: 4,
         backgroundColor: gradient,
         fill: true,
+        isPrevious: isPrevious
       }]
     } else {
       return [{
@@ -208,6 +208,7 @@ export const buildDataSet = (plot, present_index, ctx, label, isPrevious) => {
         pointHoverRadius: 4,
         backgroundColor: gradient,
         fill: true,
+        isPrevious: isPrevious
       }]
     }
   } else {
@@ -223,6 +224,7 @@ export const buildDataSet = (plot, present_index, ctx, label, isPrevious) => {
       pointHoverRadius: 4,
       backgroundColor: prev_gradient,
       fill: true,
+      isPrevious: isPrevious
     }]
   }
 }

--- a/getmangoo-analytics/assets/js/dashboard/util/date.js
+++ b/getmangoo-analytics/assets/js/dashboard/util/date.js
@@ -54,17 +54,27 @@ export function formatDayShort(date) {
 }
 
 export function parseUTCDate(dateString) {
-  var date;
-  // Safari Compatibility
-  if (typeof dateString === "string" && dateString.includes(' ')) {
-    const parts = dateString.split(/[^0-9]/);
-    parts[1] -= 1;
-    date = new Date(...parts);
-  } else {
-    date = new Date(dateString);
-  }
+  const date = parseDate(dateString);
 
-  return new Date(date.getTime() + date.getTimezoneOffset() * 60000);
+  if (isIsoDate(dateString)) {
+    return date;
+  } else {
+    return new Date(date.getTime() + date.getTimezoneOffset() * 60000);
+  }
+}
+
+const MONTH_INDEX = 1
+const MIDNIGHT_TIME_PARTS = ["00", "00", "00"]
+
+export function parseDate(dateString) {
+  const parts = dateString.split(/[^0-9]/);
+  parts[MONTH_INDEX] -= 1;
+
+  if (isIsoDate(dateString)) {
+    return new Date(...[...parts, ...MIDNIGHT_TIME_PARTS]);
+  } else {
+    return new Date(...parts);
+  }
 }
 
 // https://stackoverflow.com/a/11124448
@@ -129,4 +139,10 @@ export function isAfter(date1, date2, period) {
 
 function formatMonthShort(date) {
   return `${MONTHS[date.getMonth()].substring(0, 3)}`;
+}
+
+function isIsoDate(isoDate) {
+  const dateRegex = new RegExp(/^\d{4}-([0][1-9]|1[0-2])-([0-2][1-9]|[1-3]0|3[01])$/);
+
+  return typeof isoDate === "string" && dateRegex.test(isoDate);
 }


### PR DESCRIPTION
Fixed a bug introduced in the last hotfix by comparing both datasets index to determine if the main dataset tooltip was going to be rendered.

In this gif we can see that even though there is a point on the main dataset, as there is not comparison dataset for it the index is the same and no tooltip is rendered.

![tooltip-bug-1](https://user-images.githubusercontent.com/26199302/214928112-70c3a773-1df2-4127-8f45-8e01b0587ecd.gif)

I've fixed it by adding a new field on each dataset indicating if it is from the main or comparison dataset, so we always render the tooltip if data is present.

![tooltip-bug-1-solution](https://user-images.githubusercontent.com/26199302/214928696-d3a25406-33e2-487b-947a-087c92b062d6.gif)

Fixed another bug on tooltip that occured when we had a dataset with interval "hour" and we got closer to midnight. 

Because the "day" part on the tooltip was being converted to the UTC timezone while the "time" part to local timezone, it would change the day's number before midnight. Here it would always happen at 20:00-21:00 range as i'm at GMT-03:00.

![tooltip-bug-2](https://user-images.githubusercontent.com/26199302/214930522-db426469-7847-4717-aaba-dae74075a7f5.gif)

To fix it i've just change the code to both parts be converted to local timezone while being careful to not mess with other parts where date information is shown.

![tooltip-bug-2-solution](https://user-images.githubusercontent.com/26199302/214931260-fba3d0d5-8ce3-4218-8dbb-65ff1d0e9011.gif)

Besides that, i've fixed a typo on the README.md of the project.
